### PR TITLE
Add support for linux

### DIFF
--- a/autoload/wifi.vim
+++ b/autoload/wifi.vim
@@ -87,6 +87,8 @@ endfunction
 function! s:get_available_backend() abort
   if has('mac')
     return 'airport'
+  elseif wifi#backend#linux#is_available()
+    return 'linux'
   elseif wifi#backend#termux#is_available()
     return 'termux'
   endif

--- a/autoload/wifi/backend/linux.vim
+++ b/autoload/wifi/backend/linux.vim
@@ -1,0 +1,41 @@
+let s:Job = vital#wifi#import('System.Job')
+if filereadable('/proc/net/wireless')
+  let s:wifi_if = trim(get(split(matchstr(readfile('/proc/net/wireless'), ':'), ':'), 0))
+endif
+
+function! s:linux_update() abort dict
+  if type(self.job) is# v:t_dict && self.job.status() ==# 'run'
+    return
+  endif
+  let data = []
+  let args = ['iw', 'dev', s:wifi_if, 'link']
+  let self.job = s:Job.start(args, {
+        \ 'on_stdout': funcref('s:on_stdout', [data]),
+        \ 'on_exit': funcref('s:on_exit', [self, data]),
+        \})
+endfunction
+
+function! s:on_stdout(buffer, data) abort
+  call extend(a:buffer, a:data)
+endfunction
+
+function! s:on_exit(backend, buffer, exitval) abort
+  let content = join(a:buffer, '')
+  let a:backend.rssi = matchstr(content, 'signal: \zs\S\+')
+  let a:backend.rate = matchstr(content, 'tx bitrate: \zs\S\+')
+  let a:backend.ssid = matchstr(content, 'SSID: \zs.\{-}\ze\t')
+endfunction
+
+function! wifi#backend#linux#define() abort
+  return {
+        \ 'job': 0,
+        \ 'rssi': -100,
+        \ 'rate': 0,
+        \ 'ssid': '',
+        \ 'update': funcref('s:linux_update'),
+        \}
+endfunction
+
+function! wifi#backend#linux#is_available() abort
+  return !empty(get(s:, 'wifi_if')) && executable('iw')
+endfunction


### PR DESCRIPTION
![Screenshot-20210317170125-1366x768](https://user-images.githubusercontent.com/32936898/111443001-e9342780-8743-11eb-997d-ac14efc4a651.png)

make sure `termux#is_available` is after `linux#is_available` because termux cannot get a ssid name if the ssid is hidden, however, Android in root mode can also use the Linux backend so it can get ssid name by iw wheather the ssid is hiden. 